### PR TITLE
test: when 2 lockers run one after the other

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include .env
 
 test-mysql:
-	@go test -v -cover -coverprofile=coverage.out ./mysql \
+	@go test -race -v -cover -coverprofile=coverage.out ./mysql \
 		-driver-name=mysql \
 		-db-username=$(DB_USERNAME) \
 		-db-password=$(DB_PASSWORD) \

--- a/mysql/lock.go
+++ b/mysql/lock.go
@@ -17,6 +17,10 @@ type MySQLLocker struct {
 	db   *sql.DB
 }
 
+func (l *MySQLLocker) Name() string {
+	return l.name
+}
+
 func (l *MySQLLocker) AcquireLock(ctx context.Context, key string, timeout time.Duration) error {
 	var result sql.NullInt16
 


### PR DESCRIPTION
Running `make test-mysql` yields,
```sh
=== RUN   TestLocker_Basic
=== RUN   TestLocker_Basic/should_be_able_to_acquire_a_lock
=== RUN   TestLocker_Basic/the_key_should_be_in_acquired_state
=== RUN   TestLocker_Basic/the_key_should_not_be_free
=== RUN   TestLocker_Basic/should_be_able_to_release_the_lock
=== RUN   TestLocker_Basic/the_key_should_be_in_free_state_after_release
=== RUN   TestLocker_Basic/the_key_should_not_be_in_acquired_state_after_release
=== RUN   TestLocker_Basic/should_have_zero_keys_to_release
--- PASS: TestLocker_Basic (2.79s)
    --- PASS: TestLocker_Basic/should_be_able_to_acquire_a_lock (0.43s)
    --- PASS: TestLocker_Basic/the_key_should_be_in_acquired_state (0.43s)
    --- PASS: TestLocker_Basic/the_key_should_not_be_free (0.43s)
    --- PASS: TestLocker_Basic/should_be_able_to_release_the_lock (0.43s)
    --- PASS: TestLocker_Basic/the_key_should_be_in_free_state_after_release (0.43s)
    --- PASS: TestLocker_Basic/the_key_should_not_be_in_acquired_state_after_release (0.43s)
    --- PASS: TestLocker_Basic/should_have_zero_keys_to_release (0.21s)
=== RUN   TestLocker_TwoLockersSequential
=== RUN   TestLocker_TwoLockersSequential/test-locker-1_should_be_able_to_acquire_a_lock
=== RUN   TestLocker_TwoLockersSequential/test-locker-2_should_not_be_able_to_acquire_the_same_lock
=== RUN   TestLocker_TwoLockersSequential/test-locker-2_should_be_able_to_release_the_lock_acquired_by_test-locker-1
=== RUN   TestLocker_TwoLockersSequential/test-locker-1_should_be_able_to_release_the_lock
=== RUN   TestLocker_TwoLockersSequential/test-locker-2_should_be_able_to_acquire_the_same_lock
=== RUN   TestLocker_TwoLockersSequential/test-locker-2_should_be_able_to_release_the_lock
--- PASS: TestLocker_TwoLockersSequential (3.61s)
    --- PASS: TestLocker_TwoLockersSequential/test-locker-1_should_be_able_to_acquire_a_lock (0.43s)
    --- PASS: TestLocker_TwoLockersSequential/test-locker-2_should_not_be_able_to_acquire_the_same_lock (1.44s)
    --- PASS: TestLocker_TwoLockersSequential/test-locker-2_should_be_able_to_release_the_lock_acquired_by_test-locker-1 (0.44s)
    --- PASS: TestLocker_TwoLockersSequential/test-locker-1_should_be_able_to_release_the_lock (0.43s)
    --- PASS: TestLocker_TwoLockersSequential/test-locker-2_should_be_able_to_acquire_the_same_lock (0.44s)
    --- PASS: TestLocker_TwoLockersSequential/test-locker-2_should_be_able_to_release_the_lock (0.44s)
PASS
        github.com/bensooraj/yalock/mysql       coverage: 74.1% of statements
ok      github.com/bensooraj/yalock/mysql       9.173s  coverage: 74.1% of statements
```