### PR TITLE
test: timeout tests

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/mysql/errors.go
+++ b/mysql/errors.go
@@ -27,5 +27,4 @@ var (
 	ErrorLockDoesNotExist      = errors.New("lock does not exist")
 	ErrorLockNotOwned          = errors.New("lock not owned")
 	ErrorLockUnknown           = errors.New("unknown error")
-	ErrorContextCancelled = errors.New("context cancelled")
 )


### PR DESCRIPTION
Running `make test-mysql ` yields:
```sh
=== RUN   TestLocker_Basic
=== RUN   TestLocker_Basic/should_be_able_to_acquire_a_lock
=== RUN   TestLocker_Basic/the_key_should_be_in_acquired_state
=== RUN   TestLocker_Basic/the_key_should_not_be_free
=== RUN   TestLocker_Basic/should_be_able_to_release_the_lock
=== RUN   TestLocker_Basic/the_key_should_be_in_free_state_after_release
=== RUN   TestLocker_Basic/the_key_should_not_be_in_acquired_state_after_release
=== RUN   TestLocker_Basic/should_have_zero_keys_to_release
--- PASS: TestLocker_Basic (3.10s)
    --- PASS: TestLocker_Basic/should_be_able_to_acquire_a_lock (0.51s)
    --- PASS: TestLocker_Basic/the_key_should_be_in_acquired_state (0.61s)
    --- PASS: TestLocker_Basic/the_key_should_not_be_free (0.44s)
    --- PASS: TestLocker_Basic/should_be_able_to_release_the_lock (0.48s)
    --- PASS: TestLocker_Basic/the_key_should_be_in_free_state_after_release (0.42s)
    --- PASS: TestLocker_Basic/the_key_should_not_be_in_acquired_state_after_release (0.42s)
    --- PASS: TestLocker_Basic/should_have_zero_keys_to_release (0.21s)
=== RUN   TestLocker_TwoLockersSequential
=== RUN   TestLocker_TwoLockersSequential/test-locker-1_should_be_able_to_acquire_a_lock
=== RUN   TestLocker_TwoLockersSequential/test-locker-2_should_not_be_able_to_acquire_the_same_lock
=== RUN   TestLocker_TwoLockersSequential/test-locker-2_should_be_able_to_release_the_lock_acquired_by_test-locker-1
=== RUN   TestLocker_TwoLockersSequential/test-locker-1_should_be_able_to_release_the_lock
=== RUN   TestLocker_TwoLockersSequential/test-locker-2_should_be_able_to_acquire_the_same_lock
=== RUN   TestLocker_TwoLockersSequential/test-locker-2_should_be_able_to_release_the_lock
--- PASS: TestLocker_TwoLockersSequential (3.99s)
    --- PASS: TestLocker_TwoLockersSequential/test-locker-1_should_be_able_to_acquire_a_lock (0.48s)
    --- PASS: TestLocker_TwoLockersSequential/test-locker-2_should_not_be_able_to_acquire_the_same_lock (1.43s)
    --- PASS: TestLocker_TwoLockersSequential/test-locker-2_should_be_able_to_release_the_lock_acquired_by_test-locker-1 (0.61s)
    --- PASS: TestLocker_TwoLockersSequential/test-locker-1_should_be_able_to_release_the_lock (0.52s)
    --- PASS: TestLocker_TwoLockersSequential/test-locker-2_should_be_able_to_acquire_the_same_lock (0.51s)
    --- PASS: TestLocker_TwoLockersSequential/test-locker-2_should_be_able_to_release_the_lock (0.42s)
=== RUN   TestLocker_TwoLockersParallel
=== RUN   TestLocker_TwoLockersParallel/test-locker-1_should_be_able_to_acquire_a_lock
=== RUN   TestLocker_TwoLockersParallel/test-locker-1_should_have_no_locks_to_release
=== RUN   TestLocker_TwoLockersParallel/test-locker-2_should_have_no_locks_to_release
--- PASS: TestLocker_TwoLockersParallel (4.69s)
    --- PASS: TestLocker_TwoLockersParallel/test-locker-1_should_be_able_to_acquire_a_lock (4.07s)
    --- PASS: TestLocker_TwoLockersParallel/test-locker-1_should_have_no_locks_to_release (0.31s)
    --- PASS: TestLocker_TwoLockersParallel/test-locker-2_should_have_no_locks_to_release (0.31s)
=== RUN   TestLocker_Timeouts
=== RUN   TestLocker_Timeouts/test-locker-2_should_timeout_upon_context_timeout
=== RUN   TestLocker_Timeouts/test-locker-2_should_timeout_upon_context_cancellation
=== RUN   TestLocker_Timeouts/test-locker-2_should_timeout_waiting_on_test-locker-1
--- PASS: TestLocker_Timeouts (6.66s)
    --- PASS: TestLocker_Timeouts/test-locker-2_should_timeout_upon_context_timeout (2.00s)
    --- PASS: TestLocker_Timeouts/test-locker-2_should_timeout_upon_context_cancellation (1.42s)
    --- PASS: TestLocker_Timeouts/test-locker-2_should_timeout_waiting_on_test-locker-1 (3.24s)
PASS
        github.com/bensooraj/yalock/mysql       coverage: 73.3% of statements
ok      github.com/bensooraj/yalock/mysql       21.144s coverage: 73.3% of statements
```